### PR TITLE
Update nokogiri dependency to ~> 1.11.0.

### DIFF
--- a/fastlane-plugin-forsis.gemspec
+++ b/fastlane-plugin-forsis.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   # Don't add a dependency to fastlane or fastlane_re
   # since this would cause a circular dependency
 
-  spec.add_dependency('nokogiri', '~> 1.10.4')
+  spec.add_dependency('nokogiri', '~> 1.11.0')
 
   spec.add_development_dependency('bundler')
   spec.add_development_dependency('fastlane', '>= 2.111.0')


### PR DESCRIPTION
Updated the nokogiri dependency to ~> 1.11.0. Specs are green and I did an integration test with our SonarQube environment.

I did bump the version number.

According to Dependabot, nokogiri has one vulnerability on 1.10.x: [GHSA-vr8q-g5c7-m54m](https://github.com/advisories/GHSA-vr8q-g5c7-m54m).

Additionally, the latest released forsis version 0.1.1 depends on nokogiri ~> 1.9.0. Thus there are two additional vulnerabilities on that release:
* [CVE-2020-7595](https://github.com/advisories/GHSA-7553-jr98-vx47)
* [CVE-2019-5477](https://github.com/advisories/GHSA-cr5j-953j-xw5p)
 